### PR TITLE
Add game category to manifest, and change display mode

### DIFF
--- a/m.webmanifest
+++ b/m.webmanifest
@@ -1,11 +1,12 @@
 {
 "name": "Rock, Paper, Scissors", "short_name": "RPS",
 "description": "A small Rock, Paper Scissors game- still in developement",
+"categories": ["games"],
 "start_url": "https://zach7815.github.io/rock-Paper-Scissors",
 "lang": "en",
 "icons": [{"src": "./images/icon.svg", "sizes": "any", "type": "image/svg+xml"}],
 "background_color": "#26096e", "theme_color": "#fff",
-"display": "fullscreen",
+"display": "standalone",
 "screenshots" : [
 	{
 		"src": "./images/demo.png", "type": "image/png",


### PR DESCRIPTION
I did some more research about PWA Manifests, and it seems adding a category is a good idea (but it's very optional, so it's kinda useless). I changed the display mode to `standalone` because `fullscreen` could seem "intrusive" to some users, and the game doesn't need to be 100% immersive